### PR TITLE
Fix code scanning alert no. 1: Exception text reinterpreted as HTML

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 const tf = require('@tensorflow/tfjs-node');
+const he = require('he');
 
 const app = express();
 const port = process.env.PORT || 5000;
@@ -29,7 +30,7 @@ app.post('/predict', async (req, res) => {
     res.json(prediction);
   } catch (error) {
     console.error(error);
-    res.status(500).send(error.message);
+    res.status(500).send(he.encode(error.message));
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tensorflow/tfjs": "^4.15.0",
     "body-parser": "^1.20.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "he": "^1.2.0"
   }
 }


### PR DESCRIPTION
Fixes [https://github.com/EzioDEVio/mldockertest/security/code-scanning/1](https://github.com/EzioDEVio/mldockertest/security/code-scanning/1)

To fix the problem, we need to ensure that the error message is properly sanitized before being sent back in the response. This can be done by escaping any HTML special characters in the error message to prevent XSS attacks.

The best way to fix this is to use a library like `he` (HTML entities) to escape the error message before sending it in the response. This will ensure that any HTML or JavaScript code in the error message is rendered harmless.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
